### PR TITLE
create directory with correct name 

### DIFF
--- a/cal_uvis_monitor_stare_photometry/README.md
+++ b/cal_uvis_monitor_stare_photometry/README.md
@@ -1,0 +1,5 @@
+# WFC3/UVIS staring mode photometry pipeline
+
+Placeholder for UVIS staring mode photometry pipeline
+
+note: should write to `/grp/hst/wfc3a/manual_outputs/cal_uvis_monitor_stare_photometry`, with outputs to be displayed on the QL website copied to the additional subdirectory `display_outputs/`

--- a/cal_uvis_staring_mode_photometry/README.md
+++ b/cal_uvis_staring_mode_photometry/README.md
@@ -1,0 +1,5 @@
+# WFC3/UVIS staring mode photometry pipeline
+
+Placeholder for UVIS staring mode photometry pipeline
+
+note: should write out to `/grp/hst/wfc3a/manual_outputs/cal_uvis_staring_mode_photometry`

--- a/cal_uvis_staring_mode_photometry/README.md
+++ b/cal_uvis_staring_mode_photometry/README.md
@@ -1,5 +1,0 @@
-# WFC3/UVIS staring mode photometry pipeline
-
-Placeholder for UVIS staring mode photometry pipeline
-
-note: should write out to `/grp/hst/wfc3a/manual_outputs/cal_uvis_staring_mode_photometry`


### PR DESCRIPTION
QL convention for calibration scripts is:

`cal_<detector>_<verb>_<description>`

therefore this should be `cal_uvis_monitor_stare_photometry` instead of `cal_uvis_staring_monitor` or the like 